### PR TITLE
Fix SlowAPI handler registration

### DIFF
--- a/backend/app/routes/phone.py
+++ b/backend/app/routes/phone.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
@@ -11,8 +11,7 @@ from ..services.phone_service import analyze_phone
 limiter = Limiter(key_func=get_remote_address)
 router = APIRouter()
 
-@router.exception_handler(RateLimitExceeded)
-def rate_limit_handler(request, exc):
+def rate_limit_handler(request: Request, exc):
     return JSONResponse(
         status_code=429,
         content={
@@ -27,6 +26,6 @@ def rate_limit_handler(request, exc):
 
 @router.post('/analyze', response_model=StandardResponse)
 @limiter.limit("30/minute")
-def analyze(request: PhoneRequest):
-    result = analyze_phone(request.phone_number)
+def analyze(request: Request, payload: PhoneRequest):
+    result = analyze_phone(payload.phone_number)
     return result


### PR DESCRIPTION
## Summary
- fix RateLimitExceeded handler registration for phone router

## Testing
- `python3 -m py_compile app/routes/phone.py app/main.py app/services/phone_service.py app/models/phone.py`
- `python3 -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_685f59155c7883308ac2bdf5103c2020