### PR TITLE
Add root landing page

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,11 @@ you comply with local laws and API terms of service before running queries.
 
 For a history of changes, see [CHANGELOG.md](CHANGELOG.md).
 
+When running the FastAPI server directly, visiting `http://localhost:8000/` now
+shows a short landing page that explains how to start the React frontend. The
+actual user interface runs at `http://localhost:5173` when launched via
+`npm run dev`.
+
 ## Local Development (No Docker)
 
 ### Backend

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 from slowapi.errors import RateLimitExceeded
@@ -20,6 +21,21 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.get("/", include_in_schema=False)
+def index() -> HTMLResponse:
+    """Simple landing page explaining how to access the frontend."""
+    html = (
+        "<html><body>"
+        "<h1>ForensiTrain API</h1>"
+        "<p>The React frontend runs separately on port 5173. "
+        "Start it with <code>npm run dev</code> and open "
+        "<a href='http://localhost:5173'>http://localhost:5173</a>." 
+        "</p>"
+        "</body></html>"
+    )
+    return HTMLResponse(content=html)
 
 @app.get("/api/health")
 def health_check():


### PR DESCRIPTION
## Summary
- add simple index route that instructs how to start the React UI
- document new landing page in README

## Testing
- `python -m py_compile backend/app/main.py`
- `npm install` *(fails: 403 Forbidden)*
- `pip install -r backend/requirements.txt` *(fails: tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685f5a960054833095602798eb643ef6