### PR TITLE
Fix backend startup by shipping default env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.env
+!backend/.env
 logs/
 __pycache__/
 node_modules/

--- a/README.en.md
+++ b/README.en.md
@@ -29,7 +29,7 @@ actual user interface runs at `http://localhost:5173` when launched via
    ```bash
    pip install -r requirements.txt
    ```
-3. Copy `.env.example` to `.env` and add your API keys.
+3. Edit `backend/.env` and add your API keys.
 4. Start the API:
    ```bash
    uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
@@ -76,7 +76,7 @@ dependencies, and launches the API and React frontend concurrently.
 
 ## Docker Deployment
 
-1. Create a `.env` file in `backend/` with your API keys (see `.env.example`).
+1. Edit the provided `backend/.env` file with your API keys.
 2. Build and start the stack:
    ```bash
    docker-compose up --build

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd backend
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-cp .env.example .env  # أضف مفاتيحك هنا
+# عدل ملف backend/.env وأضف مفاتيحك هنا
 uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
@@ -35,7 +35,7 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 # 2. تشغيل الواجهة الأمامية
 cd frontend
 npm install
-cp .env.example .env  # عدل VITE_API_BASE إذا لزم
+# عدل ملف frontend/.env إذا لزم
 npm run dev
 ```
 
@@ -55,7 +55,7 @@ npm run dev
 ## 📁 ملفات التكوين والمفاتيح
 
 ```bash
-# backend/.env
+# backend/.env (موجود بالفعل، عدله بالقيم الصحيحة)
 HIBP_API_KEY=your_hibp_key
 NUMVERIFY_API_KEY=your_numverify_key
 

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,2 @@
+HIBP_API_KEY=your_hibp_key
+NUMVERIFY_API_KEY=your_numverify_key


### PR DESCRIPTION
## Summary
- add `backend/.env` with placeholder API keys so the backend container starts
- track the env file via `.gitignore`
- update documentation to edit the provided env file

## Testing
- `bash -n forensitrain_start.sh`
- `python -m py_compile backend/app/main.py backend/app/routes/phone.py backend/app/services/phone_service.py`


------
https://chatgpt.com/codex/tasks/task_e_685fbd296a8883309eb9b9284b2b39a3