### PR TITLE
Enable relationship mapping

### DIFF
--- a/backend/app/models/phone.py
+++ b/backend/app/models/phone.py
@@ -15,6 +15,8 @@ class PhoneData(BaseModel):
     name: Optional[str] = None
     accounts: List[str] = []
     breaches: List[str] = []
+    connections: List[dict] = []
+    graph: Optional[dict] = None
 
 
 class StandardResponse(BaseModel):


### PR DESCRIPTION
## Summary
- extend PhoneData with `connections` and `graph`
- log relationships to `logs/relationships.log`
- add `build_relationship_map` in `phone_service`
- return mapped connections and graph in API response

## Testing
- `black backend/app/models/phone.py backend/app/services/phone_service.py`
- `python -m py_compile backend/app/services/phone_service.py backend/app/models/phone.py`
- ❌ `pip install python-dotenv phonenumbers requests fastapi uvicorn slowapi` *(failed: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685fce2553b88330a0b4f0e7ce5d587a