### PR TITLE
Add async multi-source phone lookup

### DIFF
--- a/backend/app/models/phone.py
+++ b/backend/app/models/phone.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 from pydantic import BaseModel
 
 
@@ -17,10 +17,11 @@ class PhoneData(BaseModel):
     breaches: List[str] = []
     connections: List[dict] = []
     graph: Optional[dict] = None
+    sources_used: List[str] = []
 
 
 class StandardResponse(BaseModel):
     status: str
     data: Optional[PhoneData] = None
-    errors: Optional[str] = None
+    errors: Optional[Dict[str, Optional[str]]] = None
     timestamp: str

--- a/backend/app/routes/phone.py
+++ b/backend/app/routes/phone.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 from datetime import datetime
 
 from ..models.phone import PhoneRequest, StandardResponse
-from ..services.phone_service import analyze_phone
+from ..services.phone_service import multi_source_lookup
 
 limiter = Limiter(key_func=get_remote_address)
 router = APIRouter()
@@ -26,6 +26,6 @@ def rate_limit_handler(request: Request, exc):
 
 @router.post('/analyze', response_model=StandardResponse)
 @limiter.limit("30/minute")
-def analyze(request: Request, payload: PhoneRequest):
-    result = analyze_phone(payload.phone_number)
+async def analyze(request: Request, payload: PhoneRequest):
+    result = await multi_source_lookup(payload.phone_number)
     return result


### PR DESCRIPTION
## Summary
- support extra phone data fields via PhoneData model
- allow `errors` to return a mapping in the standard API response
- expose new async `multi_source_lookup` service that queries multiple sources concurrently
- update phone analysis route to use the async lookup

## Testing
- `python -m py_compile backend/app/services/phone_service.py backend/app/routes/phone.py backend/app/models/phone.py`
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_685fcf1332ec8330bd9a27c35ad72816