### PR TITLE
Clarify Python version and fix startup script

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -28,6 +28,13 @@ shows a short landing page that explains how to start the React frontend. The
 actual user interface runs at `http://localhost:5173` when launched via
 `npm run dev`.
 
+## Requirements
+
+- Python 3.10 or later (3.11 recommended). `dlib`, a dependency of
+  `face_recognition`, does not yet provide prebuilt wheels for Python 3.12,
+  which leads to extremely slow installation.
+- Node.js 18 or newer.
+
 ## Local Development
 
 ### Backend
@@ -35,7 +42,7 @@ actual user interface runs at `http://localhost:5173` when launched via
 1. Create a Python virtual environment and activate it:
    ```bash
    cd backend
-   python -m venv venv
+   python3.11 -m venv venv
    source venv/bin/activate  # on Windows use venv\Scripts\activate
    ```
 2. Install dependencies (includes `opencv-python-headless` for image analysis):

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 
 ## ⚙️ المتطلبات البرمجية
 
-- Python 3.10 أو أحدث.
+- Python 3.10 أو أحدث (ويفضَّل 3.11 لأن مكتبة `dlib` لا توفر بعد عجلات
+  جاهزة للإصدار 3.12 مما يؤدي إلى بطء كبير أثناء التثبيت).
 - Node.js 18 أو أحدث.
 - الحزم الموجودة في `backend/requirements.txt` و`frontend/package.json`.
 - تثبيت أداة Maigret بشكل مستقل.
@@ -29,7 +30,7 @@
 ```bash
 # 1. تشغيل الخادم الخلفي
 cd backend
-python -m venv venv
+python3.11 -m venv venv
 source venv/bin/activate
 # تتضمن المتطلبات حزمة opencv-python-headless لتحليل الصور
 pip install -r requirements.txt

--- a/forensitrain_start.sh
+++ b/forensitrain_start.sh
@@ -5,7 +5,16 @@ set -e
 echo "🚀 Starting ForensiTrain..."
 
 # Check prerequisites
-command -v python >/dev/null 2>&1 || { echo "Python is not installed" >&2; exit 1; }
+if command -v python3.11 >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v python3.11)
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v python3)
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v python)
+else
+    echo "Python is not installed" >&2
+    exit 1
+fi
 command -v npm >/dev/null 2>&1 || { echo "npm is not installed" >&2; exit 1; }
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -13,7 +22,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # ---- Backend ----
 cd "$SCRIPT_DIR/backend"
 if [ ! -d "venv" ]; then
-    python -m venv venv
+    "$PYTHON_BIN" -m venv venv
 fi
 # shellcheck disable=SC1091
 source venv/bin/activate


### PR DESCRIPTION
## Summary
- recommend using Python 3.11 in docs
- adjust backend setup instructions
- update startup script to prefer python3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686124fd4dc483308fdb110d767c1403