### PR TITLE
Fix API base path

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -68,8 +68,8 @@ actual user interface runs at `http://localhost:5173` when launched via
    ```
 
 The React app will load at http://localhost:5173. By default it queries the API
-at `http://localhost:8000/api`. You can override this by creating a `.env`
-file in `frontend/` containing `VITE_API_BASE=http://yourhost:8000/api`.
+at `/api` by default. You can override this by creating a `.env` file
+in `frontend/` containing `VITE_API_BASE=http://localhost:8000/api` for local development.
 
 All phone lookups are logged to `logs/queries.log`.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm run dev
 ## 📁 ملفات التكوين والمفاتيح
 
 ```bash
-# frontend/.env
+# frontend/.env (for local development)
 VITE_API_BASE=http://localhost:8000/api
 ```
 

--- a/forensitrain_start.sh
+++ b/forensitrain_start.sh
@@ -54,7 +54,7 @@ if [ ! -d "node_modules" ]; then
     npm install
 fi
 
-echo "🚀 Starting frontend on http://localhost:7000 ..."
+echo "🚀 Starting frontend on http://localhost:5173 ..."
 npm run dev &
 FRONTEND_PID=$!
 cd "$SCRIPT_DIR"
@@ -64,4 +64,4 @@ trap 'echo -e "\n🛑 Stopping services..."; kill $BACKEND_PID $FRONTEND_PID; ex
 
 wait $BACKEND_PID $FRONTEND_PID
 echo "✅ ForensiTrain is running successfully!"
-echo "🌐 Access the frontend at http://localhost:7000"
+echo "🌐 Access the frontend at http://localhost:5173"

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,5 @@
 export const API_BASE =
-  import.meta.env.VITE_API_BASE || 'http://localhost:8000/api'
+  import.meta.env.VITE_API_BASE || '/api'
 
 export const analyzePhone = async (phoneNumber) => {
   const res = await fetch(`${API_BASE}/phone/analyze`, {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,6 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 7000
+    port: 5173
   }
 })


### PR DESCRIPTION
## Summary
- make API base relative so production build can contact backend
- run Vite dev server on 5173 instead of 7000
- update startup script accordingly
- clarify example `.env` usage in docs

## Testing
- `node -e "console.log('test')"`
- `python -m py_compile backend/app/**/*.py`
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861434b4b988330afdee01b3d43eebb