### PR TITLE
Fix face_recognition import scope

### DIFF
--- a/backend/app/services/image_service.py
+++ b/backend/app/services/image_service.py
@@ -4,7 +4,6 @@ from PIL import Image
 import numpy as np
 import pytesseract
 import piexif
-import face_recognition
 import cvlib as cv
 
 
@@ -39,6 +38,8 @@ def _infer_platform(text: str) -> Optional[str]:
 
 
 def analyze_image_bytes(data: bytes) -> Dict:
+    import face_recognition
+
     img = Image.open(io.BytesIO(data))
     width, height = img.size
     fmt = img.format or "unknown"


### PR DESCRIPTION
## Summary
- avoid loading heavy models on startup by moving `face_recognition` import

## Testing
- `python -m py_compile backend/app/services/image_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686155af0a188330ba85630ed4f50076