### PR TITLE
Add OSINT utilities and tests

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -99,3 +99,20 @@ returns a list of optional packages and whether they loaded successfully.
 5. Check `logs/queries.log` for a new entry.
 6. Try an invalid number to verify an error message is shown.
 
+### Extra OSINT Utilities
+
+Some advanced helpers require free API keys. Create a `.env` file in
+`backend/` with the following variables:
+
+```
+OCR_SPACE_KEY=your_ocr_space_key
+ANYMAILFINDER_KEY=your_anymailfinder_key
+PROXYCURL_KEY=your_proxycurl_key
+APIFY_TOKEN=your_apify_token
+SOCIAL_SEARCHER_KEY=your_social_searcher_key
+```
+
+All mentioned services offer free tiers. Sign up on their sites and copy the
+provided keys. The helper functions in `misc_profile_service.py` will use these
+keys automatically.
+

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -7,6 +7,13 @@ from .phone_service import (
 from .osint_service import extract_osint_footprint
 from .recursive_osint_engine import smart_osint_lookup
 from .identity_enrichment_service import enrich_identity
+from .misc_profile_service import (
+    extract_text_from_image,
+    validate_and_normalize_email,
+    find_profiles_by_email,
+    find_profiles_by_name,
+    aggregate_results,
+)
 
 __all__ = [
     'analyze_phone',
@@ -16,4 +23,9 @@ __all__ = [
     'extract_osint_footprint',
     'smart_osint_lookup',
     'enrich_identity',
+    'extract_text_from_image',
+    'validate_and_normalize_email',
+    'find_profiles_by_email',
+    'find_profiles_by_name',
+    'aggregate_results',
 ]

--- a/backend/app/services/misc_profile_service.py
+++ b/backend/app/services/misc_profile_service.py
@@ -1,0 +1,178 @@
+import io
+import os
+from typing import Dict, List, Optional
+
+import requests
+from PIL import Image
+import pytesseract
+from bs4 import BeautifulSoup
+
+from .advanced_osint_service import (
+    apify_social_media_finder,
+    social_searcher_mentions,
+)
+
+
+OCR_SPACE_API = "https://api.ocr.space/parse/image"
+
+
+def extract_text_from_image(image_bytes: bytes) -> str:
+    """Return visible text in an image using OCR.space or Tesseract."""
+    api_key = os.getenv("OCR_SPACE_KEY")
+    if api_key:
+        try:
+            resp = requests.post(
+                OCR_SPACE_API,
+                files={"filename": ("image.jpg", image_bytes)},
+                data={"language": "eng", "apikey": api_key, "isOverlayRequired": False},
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                text_parts = [res.get("ParsedText", "") for res in data.get("ParsedResults", [])]
+                text = " ".join(text_parts).strip()
+                if text:
+                    return text
+        except Exception:
+            pass
+    try:
+        img = Image.open(io.BytesIO(image_bytes))
+        text = pytesseract.image_to_string(img, lang="ara")
+        return text.strip()
+    except Exception:
+        return ""
+
+
+def validate_and_normalize_email(email_str: str) -> Dict[str, object]:
+    """Check email syntax and existence via Anymail Finder."""
+    result = {"valid": False, "email": email_str.strip().lower()}
+    api_key = os.getenv("ANYMAILFINDER_KEY")
+    if api_key:
+        try:
+            resp = requests.get(
+                "https://api.anymailfinder.com/v5.0/search/verify",
+                params={"email": result["email"]},
+                headers={"X-Api-Key": api_key},
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                result["valid"] = data.get("status") == "deliverable"
+                result["email"] = data.get("email", result["email"])
+                return result
+        except Exception:
+            pass
+    try:
+        from email_validator import validate_email, EmailNotValidError
+
+        info = validate_email(email_str, check_deliverability=True)
+        result["valid"] = True
+        result["email"] = info.email
+    except (EmailNotValidError, Exception):
+        result["valid"] = False
+    return result
+
+
+def find_profiles_by_email(email_str: str) -> Dict[str, Optional[str]]:
+    """Use Proxycurl to resolve social profiles from an email."""
+    api_key = os.getenv("PROXYCURL_KEY")
+    result = {"facebook": None, "linkedin": None, "twitter": None}
+    if not api_key:
+        return result
+    try:
+        resp = requests.get(
+            "https://nubela.co/proxycurl/api/v2/linkedin/profile/resolve/email",
+            params={"email": email_str},
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            result["linkedin"] = data.get("linkedin_profile_url")
+            result["facebook"] = data.get("facebook_url")
+            result["twitter"] = data.get("twitter_url")
+    except Exception:
+        pass
+    return result
+
+
+def find_profiles_by_name(name_str: str) -> List[str]:
+    """Search for social media profiles by name using Apify or SocialSearcher."""
+    results: List[str] = []
+    token = os.getenv("APIFY_TOKEN")
+    if token:
+        try:
+            items = apify_social_media_finder(name_str, token)
+            for item in items:
+                for key in ("facebook", "linkedin", "twitter", "instagram"):
+                    url = item.get(key) or item.get(f"{key}_url")
+                    if url:
+                        results.append(url)
+        except Exception:
+            pass
+    api_key = os.getenv("SOCIAL_SEARCHER_KEY")
+    if not results and api_key:
+        try:
+            posts = social_searcher_mentions(name_str, api_key)
+            for p in posts:
+                url = p.get("url")
+                if url:
+                    results.append(url)
+        except Exception:
+            pass
+    return list(dict.fromkeys(results))
+
+
+def _fetch_profile_picture(url: str) -> Optional[str]:
+    try:
+        resp = requests.get(url, timeout=10)
+        if resp.status_code == 200:
+            soup = BeautifulSoup(resp.text, "html.parser")
+            meta = soup.find("meta", property="og:image") or soup.find(
+                "meta", attrs={"name": "twitter:image"}
+            )
+            if meta and meta.get("content"):
+                return meta["content"]
+            img = soup.find("img")
+            if img and img.get("src"):
+                return img["src"]
+    except Exception:
+        pass
+    return None
+
+
+def aggregate_results(
+    image_bytes: Optional[bytes], email_list: List[str], name_str: str
+) -> Dict[str, object]:
+    """Run full OSINT pipeline and return combined results."""
+
+    text = extract_text_from_image(image_bytes) if image_bytes else ""
+
+    validated = [validate_and_normalize_email(e) for e in email_list]
+    valid_emails = [r["email"] for r in validated if r["valid"]]
+
+    profiles: Dict[str, Optional[str]] = {}
+    profile_pics: List[str] = []
+    for e in valid_emails:
+        found = find_profiles_by_email(e)
+        for key, url in found.items():
+            if url and key not in profiles:
+                profiles[key] = url
+                pic = _fetch_profile_picture(url)
+                if pic:
+                    profile_pics.append(pic)
+
+    name_urls = find_profiles_by_name(name_str)
+    for url in name_urls:
+        if url not in profiles.values():
+            pic = _fetch_profile_picture(url)
+            if pic:
+                profile_pics.append(pic)
+    combined_urls = list(dict.fromkeys(list(profiles.values()) + name_urls))
+
+    return {
+        "text": text,
+        "emails": validated,
+        "profiles": combined_urls,
+        "profile_pictures": list(dict.fromkeys(profile_pics)),
+    }

--- a/tests/test_misc_profile_service.py
+++ b/tests/test_misc_profile_service.py
@@ -1,0 +1,75 @@
+import io
+from unittest import mock
+
+import os
+import sys
+import pytest
+import types
+
+sys.modules.setdefault('httpx', types.SimpleNamespace())
+sys.modules.setdefault('bs4', types.SimpleNamespace(BeautifulSoup=lambda *a, **k: None))
+email_mod = types.SimpleNamespace(
+    validate_email=lambda e, check_deliverability=True: types.SimpleNamespace(email=e),
+    EmailNotValidError=Exception,
+)
+sys.modules.setdefault('email_validator', email_mod)
+sys.modules.setdefault('requests', types.SimpleNamespace(get=lambda *a, **k: None, post=lambda *a, **k: None))
+sys.modules.setdefault('PIL', types.SimpleNamespace(Image=types.SimpleNamespace(open=lambda *a, **k: None)))
+sys.modules.setdefault('pytesseract', types.SimpleNamespace(image_to_string=lambda *a, **k: ""))
+
+services_path = os.path.join(os.path.dirname(__file__), "..", "backend", "app", "services")
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "backend"))
+import importlib.util, types as _types
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+import importlib, types as _types
+app_pkg = _types.ModuleType("app")
+services_pkg = _types.ModuleType("app.services")
+services_pkg.__path__ = [services_path]
+sys.modules['app'] = app_pkg
+sys.modules['app.services'] = services_pkg
+sys.modules.setdefault('app.services.advanced_osint_service', _types.SimpleNamespace(
+    apify_social_media_finder=lambda *a, **k: [],
+    social_searcher_mentions=lambda *a, **k: [],
+))
+sys.modules.setdefault('app.services.phone_service', _types.ModuleType('phone_service'))
+sys.modules.setdefault('app.services.osint_service', _types.ModuleType('osint_service'))
+sys.modules.setdefault('app.services.recursive_osint_engine', _types.ModuleType('recursive_osint_engine'))
+sys.modules.setdefault('app.services.identity_enrichment_service', _types.ModuleType('identity_enrichment_service'))
+mps = importlib.import_module('app.services.misc_profile_service')
+
+
+@pytest.fixture
+def dummy_image_bytes():
+    return b"fake"
+
+
+def test_extract_text_ocrspace(dummy_image_bytes):
+    with mock.patch("requests.post") as mpost, mock.patch.dict(os.environ, {"OCR_SPACE_KEY": "KEY"}):
+        mpost.return_value.status_code = 200
+        mpost.return_value.json.return_value = {"ParsedResults": [{"ParsedText": "text"}]}
+        text = mps.extract_text_from_image(dummy_image_bytes)
+        assert text == "text"
+
+
+def test_validate_and_normalize_email_api():
+    with mock.patch("requests.get") as mget, mock.patch.dict(os.environ, {"ANYMAILFINDER_KEY": "K"}):
+        mget.return_value.status_code = 200
+        mget.return_value.json.return_value = {"status": "deliverable", "email": "a@b.c"}
+        res = mps.validate_and_normalize_email("A@B.c")
+        assert res["valid"] is True
+        assert res["email"] == "a@b.c"
+
+
+def test_find_profiles_by_email():
+    with mock.patch("requests.get") as mget, mock.patch.dict(os.environ, {"PROXYCURL_KEY": "K"}):
+        mget.return_value.status_code = 200
+        mget.return_value.json.return_value = {"linkedin_profile_url": "https://linkedin.com/in/test"}
+        res = mps.find_profiles_by_email("a@b.c")
+        assert res["linkedin"]
+
+
+def test_find_profiles_by_name_apify():
+    with mock.patch.object(mps, "apify_social_media_finder") as finder, mock.patch.dict(os.environ, {"APIFY_TOKEN": "T"}):
+        finder.return_value = [{"facebook": "http://fb.com/x"}]
+        urls = mps.find_profiles_by_name("john")
+        assert "http://fb.com/x" in urls


### PR DESCRIPTION
## Summary
- implement misc_profile_service with OCR.space, email validation and OSINT helpers
- expose new service functions
- document setup for API keys in README
- add unit tests for misc_profile_service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cf0047e08330ae2899b2ec6bd357