### PR TITLE
Add dashboard UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,10 @@
     "react-force-graph-2d": "^1.27.1",
     "react-i18next": "^13.2.0",
     "react-icons": "^4.10.1",
-    "react-router-dom": "^6.17.0"
+    "react-router-dom": "^6.17.0",
+    "recharts": "^2.7.0",
+    "react-leaflet": "^4.3.1",
+    "leaflet": "^1.9.4"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import PhoneLookupPage from './pages/PhoneLookupPage';
 import GraphView from './components/GraphView';
 import ExportPage from './components/ExportPage';
 import ImageAnalysis from './components/ImageAnalysis';
+import DashboardPage from './pages/DashboardPage';
 import { enrichPhone } from './services/api';
 
  
@@ -49,6 +50,7 @@ function App() {
         <div className="p-4 max-w-3xl mx-auto text-gray-900 dark:bg-gray-800 dark:text-gray-100 min-h-screen">
           <Navbar toggleTheme={toggleTheme} theme={theme} />
           <nav className="mb-4 flex gap-4">
+            <Link to="/dashboard">Dashboard</Link>
             <Link to="/">{t('general')}</Link>
             <Link to="/graph">{t('graph')}</Link>
             <Link to="/image">{t('image_analysis')}</Link>
@@ -72,7 +74,9 @@ function App() {
                 <GraphPage result={result} loading={loading} error={error} />
               }
             />
- 
+
+            <Route path="/dashboard" element={<DashboardPage />} />
+
             <Route path="/image" element={<ImageAnalysis />} />
             <Route path="/export" element={<ExportPage phone={result?.phone_number} />} />
           </Routes>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import 'leaflet/dist/leaflet.css';
+
+html,
+body,
+#root {
+  height: 100%;
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import { motion } from 'framer-motion';
+import 'leaflet/dist/leaflet.css';
+
+const sampleStats = [
+  { name: 'New Data', value: 1234 },
+  { name: 'Verified Contacts', value: 567 },
+  { name: 'Alerts', value: 9 },
+];
+
+const lineData = [
+  { name: 'Mon', queries: 30 },
+  { name: 'Tue', queries: 45 },
+  { name: 'Wed', queries: 50 },
+  { name: 'Thu', queries: 65 },
+  { name: 'Fri', queries: 40 },
+  { name: 'Sat', queries: 55 },
+  { name: 'Sun', queries: 30 },
+];
+
+const barData = [
+  { name: 'Emails', count: 400 },
+  { name: 'Phones', count: 300 },
+  { name: 'Images', count: 200 },
+  { name: 'Profiles', count: 278 },
+];
+
+const alerts = [
+  { id: 1, message: 'Possible breach detected', level: 'high', time: '10:24' },
+  { id: 2, message: 'New social profile linked', level: 'medium', time: '11:15' },
+  { id: 3, message: 'Image analysis completed', level: 'low', time: '12:05' },
+];
+
+const DashboardPage = () => (
+  <div className="flex h-full bg-gray-900 text-gray-100">
+    <aside className="w-64 bg-gray-800 p-4 hidden md:block">
+      <h2 className="text-xl font-bold mb-4 text-blue-400">IntelBoard</h2>
+      <nav className="space-y-2">
+        <a href="#" className="block hover:text-blue-400">Dashboard</a>
+        <a href="#" className="block hover:text-blue-400">Phone Lookup</a>
+        <a href="#" className="block hover:text-blue-400">Image Analysis</a>
+      </nav>
+    </aside>
+    <main className="flex-1 overflow-auto p-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+        {sampleStats.map((s, idx) => (
+          <motion.div
+            key={idx}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: idx * 0.1 }}
+            className="bg-gray-800 p-4 rounded shadow"
+          >
+            <p className="text-sm uppercase text-gray-400">{s.name}</p>
+            <p className="text-2xl font-bold text-blue-400">{s.value}</p>
+          </motion.div>
+        ))}
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+        <div className="bg-gray-800 p-4 rounded shadow h-64">
+          <p className="mb-2 font-semibold">Weekly Queries</p>
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={lineData}>
+              <CartesianGrid stroke="#374151" />
+              <XAxis dataKey="name" stroke="#9ca3af" />
+              <YAxis stroke="#9ca3af" />
+              <Tooltip />
+              <Line type="monotone" dataKey="queries" stroke="#60a5fa" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="bg-gray-800 p-4 rounded shadow h-64">
+          <p className="mb-2 font-semibold">Data Types</p>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={barData}>
+              <CartesianGrid stroke="#374151" />
+              <XAxis dataKey="name" stroke="#9ca3af" />
+              <YAxis stroke="#9ca3af" />
+              <Tooltip />
+              <Bar dataKey="count" fill="#34d399" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="bg-gray-800 p-4 rounded shadow h-64">
+          <p className="mb-2 font-semibold">Activity Map</p>
+          <MapContainer center={[51.505, -0.09]} zoom={2} className="h-full w-full">
+            <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+            <Marker position={[51.505, -0.09]}>
+              <Popup>Sample location</Popup>
+            </Marker>
+          </MapContainer>
+        </div>
+        <div className="bg-gray-800 p-4 rounded shadow overflow-auto">
+          <p className="mb-2 font-semibold">Alerts</p>
+          <ul className="space-y-2">
+            {alerts.map(a => (
+              <li key={a.id} className="border-b border-gray-700 pb-2">
+                <span className={`mr-2 px-2 py-0.5 text-xs rounded ${a.level === 'high' ? 'bg-red-500' : a.level === 'medium' ? 'bg-yellow-500' : 'bg-green-500'}`}>{a.level.toUpperCase()}</span>
+                {a.message}
+                <span className="float-right text-xs text-gray-400">{a.time}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </main>
+  </div>
+);
+
+export default DashboardPage;


### PR DESCRIPTION
## Summary
- add a new responsive Dashboard page with charts, map and alerts
- hook Dashboard route into the React app navigation
- include leaflet styles and height for full-page layout
- declare chart and map libraries in package.json

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686205069afc833099a1fa0f88a0e5e8