### PR TITLE
Fix react-leaflet peer dependency issue

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "react-icons": "^4.10.1",
     "react-router-dom": "^6.17.0",
     "recharts": "^2.7.0",
-    "react-leaflet": "^4.3.1",
+    "react-leaflet": "^4.2.1",
     "leaflet": "^1.9.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- pin `react-leaflet` to a published v4 release compatible with React 18

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862076ea4dc8330a856bf45dda63ff8