### PR TITLE
Add advanced SOC-style dashboard UI

### DIFF
--- a/frontend/src/components/dashboard/AlertCenter.jsx
+++ b/frontend/src/components/dashboard/AlertCenter.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { FiXCircle, FiAlertTriangle } from 'react-icons/fi';
+
+const initialAlerts = [
+  { id: 1, message: 'Possible breach detected', level: 'high', time: '10:24' },
+  { id: 2, message: 'New social profile linked', level: 'medium', time: '11:15' },
+  { id: 3, message: 'Image analysis completed', level: 'low', time: '12:05' },
+];
+
+const colors = {
+  high: 'bg-red-500',
+  medium: 'bg-yellow-500',
+  low: 'bg-green-500',
+};
+
+const AlertCenter = () => {
+  const [alerts, setAlerts] = useState(initialAlerts);
+  const dismiss = (id) => setAlerts((a) => a.filter((al) => al.id !== id));
+  return (
+    <div className="bg-gray-800/60 backdrop-blur-lg rounded shadow p-4 overflow-auto">
+      <p className="mb-2 font-semibold">Alerts</p>
+      <ul className="space-y-2">
+        {alerts.map((a) => (
+          <li key={a.id} className="flex items-center justify-between border-b border-gray-700 pb-1">
+            <span className={`mr-2 px-2 py-0.5 text-xs rounded ${colors[a.level]}`}>{a.level.toUpperCase()}</span>
+            <span className="flex-1 text-sm">{a.message}</span>
+            <span className="text-xs text-gray-400 mr-2">{a.time}</span>
+            <button onClick={() => dismiss(a.id)} aria-label="Dismiss">
+              <FiXCircle className="text-gray-500 hover:text-red-400" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AlertCenter;

--- a/frontend/src/components/dashboard/DataStreamPanel.jsx
+++ b/frontend/src/components/dashboard/DataStreamPanel.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+const sample = [
+  'New phone number +12024561111 collected',
+  'Email test@example.com verified',
+  'Image processed: IMG_001.png',
+];
+
+const DataStreamPanel = () => {
+  const [items, setItems] = useState(sample);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setItems((prev) => [
+        `Activity ${prev.length + 1} detected`,
+        ...prev.slice(0, 49),
+      ]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="bg-gray-800/60 backdrop-blur-lg rounded shadow p-4 h-64 overflow-auto">
+      <p className="mb-2 font-semibold">Live Stream</p>
+      <ul className="space-y-1 text-sm">
+        {items.map((i, idx) => (
+          <li key={idx} className="animate-fade-in">{i}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DataStreamPanel;

--- a/frontend/src/components/dashboard/ImageGrid.jsx
+++ b/frontend/src/components/dashboard/ImageGrid.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const images = [
+  { src: 'https://via.placeholder.com/80', confidence: 92 },
+  { src: 'https://via.placeholder.com/80', confidence: 75 },
+  { src: 'https://via.placeholder.com/80', confidence: 60 },
+];
+
+const ImageGrid = () => (
+  <div className="bg-gray-800/60 backdrop-blur-lg rounded shadow p-4 h-64 overflow-auto">
+    <p className="mb-2 font-semibold">Image Analysis</p>
+    <div className="grid grid-cols-3 gap-2">
+      {images.map((img, idx) => (
+        <div key={idx} className="relative">
+          <img src={img.src} alt="thumb" className="rounded" />
+          <span className="absolute bottom-1 right-1 text-xs bg-black/60 px-1 rounded">
+            {img.confidence}%
+          </span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default ImageGrid;

--- a/frontend/src/components/dashboard/MapWidget.jsx
+++ b/frontend/src/components/dashboard/MapWidget.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+const MapWidget = () => (
+  <div className="bg-gray-800/60 backdrop-blur-lg rounded shadow p-4 h-64">
+    <p className="mb-2 font-semibold">Geo Activity</p>
+    <MapContainer center={[20, 0]} zoom={2} className="h-full w-full rounded">
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      <Marker position={[51.5, -0.09]}>
+        <Popup>Sample location</Popup>
+      </Marker>
+    </MapContainer>
+  </div>
+);
+
+export default MapWidget;

--- a/frontend/src/components/dashboard/ProfileMenu.jsx
+++ b/frontend/src/components/dashboard/ProfileMenu.jsx
@@ -1,0 +1,39 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { FiUser, FiChevronDown } from 'react-icons/fi';
+
+const ProfileMenu = () => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handle = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handle);
+    return () => document.removeEventListener('click', handle);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1 text-gray-200 hover:text-blue-400 focus:outline-none"
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        <FiUser />
+        <FiChevronDown />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 bg-gray-800/70 backdrop-blur-md rounded shadow-lg py-2 text-sm" role="menu">
+          <a href="#" className="block px-3 py-1 hover:bg-gray-700" role="menuitem">Settings</a>
+          <a href="#" className="block px-3 py-1 hover:bg-gray-700" role="menuitem">Logout</a>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProfileMenu;

--- a/frontend/src/components/dashboard/Sidebar.jsx
+++ b/frontend/src/components/dashboard/Sidebar.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { FiMenu, FiGrid, FiSearch, FiImage, FiAlertCircle } from 'react-icons/fi';
+
+const Sidebar = () => {
+  const [open, setOpen] = useState(true);
+  const items = [
+    { label: 'Dashboard', icon: <FiGrid /> },
+    { label: 'Phone Lookup', icon: <FiSearch /> },
+    { label: 'Image Analysis', icon: <FiImage /> },
+    { label: 'Alerts', icon: <FiAlertCircle /> },
+  ];
+  return (
+    <div className={`bg-gray-800/60 backdrop-blur-md text-gray-100 h-full p-4 transition-all duration-300 ${open ? 'w-64' : 'w-16'}`}> 
+      <button
+        className="text-gray-400 hover:text-blue-400 mb-6 focus:outline-none"
+        onClick={() => setOpen(!open)}
+        aria-label="Toggle sidebar"
+      >
+        <FiMenu />
+      </button>
+      <nav className="space-y-4">
+        {items.map((item) => (
+          <a
+            key={item.label}
+            href="#"
+            className="flex items-center gap-2 hover:text-blue-400"
+          >
+            {item.icon}
+            {open && <span>{item.label}</span>}
+          </a>
+        ))}
+      </nav>
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/components/dashboard/SocialAccountsPanel.jsx
+++ b/frontend/src/components/dashboard/SocialAccountsPanel.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { FiCheckCircle, FiClock } from 'react-icons/fi';
+
+const accounts = [
+  { platform: 'Twitter', user: '@intel', status: 'verified' },
+  { platform: 'Facebook', user: 'John Doe', status: 'pending' },
+  { platform: 'Instagram', user: '@instaUser', status: 'verified' },
+];
+
+const SocialAccountsPanel = () => (
+  <div className="bg-gray-800/60 backdrop-blur-lg rounded shadow p-4 h-64 overflow-auto">
+    <p className="mb-2 font-semibold">Linked Accounts</p>
+    <ul className="space-y-2 text-sm">
+      {accounts.map((acc, idx) => (
+        <li key={idx} className="flex items-center justify-between">
+          <span>{acc.platform} - {acc.user}</span>
+          {acc.status === 'verified' ? (
+            <FiCheckCircle className="text-green-400" />
+          ) : (
+            <FiClock className="text-yellow-400" />
+          )}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default SocialAccountsPanel;

--- a/frontend/src/components/dashboard/StatsCard.jsx
+++ b/frontend/src/components/dashboard/StatsCard.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+const ACCENTS = {
+  blue: 'text-blue-400',
+  green: 'text-green-400',
+  orange: 'text-orange-400',
+};
+
+const StatsCard = ({ label, value, accent = 'blue' }) => {
+  const [display, setDisplay] = useState(0);
+  useEffect(() => {
+    let frame;
+    const duration = 800;
+    const start = performance.now();
+    const animate = (time) => {
+      const progress = Math.min((time - start) / duration, 1);
+      setDisplay(Math.floor(progress * value));
+      if (progress < 1) frame = requestAnimationFrame(animate);
+    };
+    frame = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frame);
+  }, [value]);
+  const color = ACCENTS[accent] || ACCENTS.blue;
+  return (
+    <div className="p-4 rounded-lg shadow bg-gray-800/60 backdrop-blur-lg">
+      <p className="text-sm uppercase text-gray-400">{label}</p>
+      <p className={`text-3xl font-bold ${color}`}>{display}</p>
+    </div>
+  );
+};
+
+export default StatsCard;

--- a/frontend/src/components/dashboard/StatsCharts.jsx
+++ b/frontend/src/components/dashboard/StatsCharts.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { LineChart, Line, BarChart, Bar, RadialBarChart, RadialBar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+const lineData = [
+  { name: 'Mon', queries: 30 },
+  { name: 'Tue', queries: 45 },
+  { name: 'Wed', queries: 50 },
+  { name: 'Thu', queries: 65 },
+  { name: 'Fri', queries: 40 },
+  { name: 'Sat', queries: 55 },
+  { name: 'Sun', queries: 30 },
+];
+
+const barData = [
+  { name: 'Emails', count: 400 },
+  { name: 'Phones', count: 300 },
+  { name: 'Images', count: 200 },
+  { name: 'Profiles', count: 278 },
+];
+
+const radialData = [
+  { name: 'Verification', value: 76, fill: '#60a5fa' },
+];
+
+const StatsCharts = () => (
+  <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+    <div className="bg-gray-800/60 backdrop-blur-lg p-4 rounded shadow h-64">
+      <p className="mb-2 font-semibold">Weekly Queries</p>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={lineData}>
+          <CartesianGrid stroke="#374151" />
+          <XAxis dataKey="name" stroke="#9ca3af" />
+          <YAxis stroke="#9ca3af" />
+          <Tooltip />
+          <Line type="monotone" dataKey="queries" stroke="#60a5fa" strokeWidth={2} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+    <div className="bg-gray-800/60 backdrop-blur-lg p-4 rounded shadow h-64">
+      <p className="mb-2 font-semibold">Data Types</p>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={barData}>
+          <CartesianGrid stroke="#374151" />
+          <XAxis dataKey="name" stroke="#9ca3af" />
+          <YAxis stroke="#9ca3af" />
+          <Tooltip />
+          <Bar dataKey="count" fill="#34d399" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+    <div className="bg-gray-800/60 backdrop-blur-lg p-4 rounded shadow h-64 flex items-center justify-center">
+      <ResponsiveContainer width="100%" height="80%">
+        <RadialBarChart innerRadius="80%" outerRadius="100%" data={radialData} startAngle={180} endAngle={0}>
+          <RadialBar minAngle={15} background clockWise dataKey="value" />
+        </RadialBarChart>
+      </ResponsiveContainer>
+      <div className="absolute text-2xl text-blue-400 font-bold">76%</div>
+    </div>
+  </div>
+);
+
+export default StatsCharts;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,3 +9,12 @@ body,
 #root {
   height: 100%;
 }
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.5s ease-in;
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,111 +1,44 @@
 import React from 'react';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import Sidebar from '../components/dashboard/Sidebar';
+import ProfileMenu from '../components/dashboard/ProfileMenu';
+import StatsCard from '../components/dashboard/StatsCard';
+import StatsCharts from '../components/dashboard/StatsCharts';
+import MapWidget from '../components/dashboard/MapWidget';
+import DataStreamPanel from '../components/dashboard/DataStreamPanel';
+import SocialAccountsPanel from '../components/dashboard/SocialAccountsPanel';
+import ImageGrid from '../components/dashboard/ImageGrid';
+import AlertCenter from '../components/dashboard/AlertCenter';
 import { motion } from 'framer-motion';
-import 'leaflet/dist/leaflet.css';
 
-const sampleStats = [
-  { name: 'New Data', value: 1234 },
-  { name: 'Verified Contacts', value: 567 },
-  { name: 'Alerts', value: 9 },
-];
-
-const lineData = [
-  { name: 'Mon', queries: 30 },
-  { name: 'Tue', queries: 45 },
-  { name: 'Wed', queries: 50 },
-  { name: 'Thu', queries: 65 },
-  { name: 'Fri', queries: 40 },
-  { name: 'Sat', queries: 55 },
-  { name: 'Sun', queries: 30 },
-];
-
-const barData = [
-  { name: 'Emails', count: 400 },
-  { name: 'Phones', count: 300 },
-  { name: 'Images', count: 200 },
-  { name: 'Profiles', count: 278 },
-];
-
-const alerts = [
-  { id: 1, message: 'Possible breach detected', level: 'high', time: '10:24' },
-  { id: 2, message: 'New social profile linked', level: 'medium', time: '11:15' },
-  { id: 3, message: 'Image analysis completed', level: 'low', time: '12:05' },
+const stats = [
+  { label: 'New Data', value: 1234, accent: 'blue' },
+  { label: 'Verified Contacts', value: 567, accent: 'green' },
+  { label: 'Active Alerts', value: 9, accent: 'orange' },
 ];
 
 const DashboardPage = () => (
-  <div className="flex h-full bg-gray-900 text-gray-100">
-    <aside className="w-64 bg-gray-800 p-4 hidden md:block">
-      <h2 className="text-xl font-bold mb-4 text-blue-400">IntelBoard</h2>
-      <nav className="space-y-2">
-        <a href="#" className="block hover:text-blue-400">Dashboard</a>
-        <a href="#" className="block hover:text-blue-400">Phone Lookup</a>
-        <a href="#" className="block hover:text-blue-400">Image Analysis</a>
-      </nav>
-    </aside>
-    <main className="flex-1 overflow-auto p-4">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-        {sampleStats.map((s, idx) => (
-          <motion.div
-            key={idx}
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: idx * 0.1 }}
-            className="bg-gray-800 p-4 rounded shadow"
-          >
-            <p className="text-sm uppercase text-gray-400">{s.name}</p>
-            <p className="text-2xl font-bold text-blue-400">{s.value}</p>
+  <div className="flex h-full bg-gray-900 text-gray-100 font-sans">
+    <Sidebar />
+    <main className="flex-1 overflow-auto p-4 space-y-4">
+      <div className="flex justify-end">
+        <ProfileMenu />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {stats.map((s, idx) => (
+          <motion.div key={idx} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: idx * 0.1 }}>
+            <StatsCard label={s.label} value={s.value} accent={s.accent} />
           </motion.div>
         ))}
       </div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
-        <div className="bg-gray-800 p-4 rounded shadow h-64">
-          <p className="mb-2 font-semibold">Weekly Queries</p>
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={lineData}>
-              <CartesianGrid stroke="#374151" />
-              <XAxis dataKey="name" stroke="#9ca3af" />
-              <YAxis stroke="#9ca3af" />
-              <Tooltip />
-              <Line type="monotone" dataKey="queries" stroke="#60a5fa" strokeWidth={2} />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-        <div className="bg-gray-800 p-4 rounded shadow h-64">
-          <p className="mb-2 font-semibold">Data Types</p>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={barData}>
-              <CartesianGrid stroke="#374151" />
-              <XAxis dataKey="name" stroke="#9ca3af" />
-              <YAxis stroke="#9ca3af" />
-              <Tooltip />
-              <Bar dataKey="count" fill="#34d399" />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
+      <StatsCharts />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div className="bg-gray-800 p-4 rounded shadow h-64">
-          <p className="mb-2 font-semibold">Activity Map</p>
-          <MapContainer center={[51.505, -0.09]} zoom={2} className="h-full w-full">
-            <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-            <Marker position={[51.505, -0.09]}>
-              <Popup>Sample location</Popup>
-            </Marker>
-          </MapContainer>
-        </div>
-        <div className="bg-gray-800 p-4 rounded shadow overflow-auto">
-          <p className="mb-2 font-semibold">Alerts</p>
-          <ul className="space-y-2">
-            {alerts.map(a => (
-              <li key={a.id} className="border-b border-gray-700 pb-2">
-                <span className={`mr-2 px-2 py-0.5 text-xs rounded ${a.level === 'high' ? 'bg-red-500' : a.level === 'medium' ? 'bg-yellow-500' : 'bg-green-500'}`}>{a.level.toUpperCase()}</span>
-                {a.message}
-                <span className="float-right text-xs text-gray-400">{a.time}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+        <MapWidget />
+        <AlertCenter />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <DataStreamPanel />
+        <SocialAccountsPanel />
+        <ImageGrid />
       </div>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- implement collapsible sidebar and profile menu
- add animated KPI cards, stats charts, and widgets
- show data stream, linked accounts, images, map and alert center
- refine global styles with animation helpers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620a0309f8833088a737b05ba48bcc