### PR TITLE
Add cockpit-style widgets

### DIFF
--- a/frontend/src/components/dashboard/AnalogGauge.jsx
+++ b/frontend/src/components/dashboard/AnalogGauge.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+/**
+ * Analog style gauge with digital readout for displaying vital statistics.
+ * Uses SVG arcs and rotation for the needle animation.
+ */
+const AnalogGauge = ({ value = 50, max = 100, label = 'Gauge' }) => {
+  // Clamp the value between 0 and max
+  const val = Math.max(0, Math.min(value, max));
+  const angle = (val / max) * 180 - 90; // 180deg sweep
+  return (
+    <div className="bg-gray-800/60 backdrop-blur-lg rounded shadow p-4 flex flex-col items-center">
+      <svg viewBox="0 0 100 60" className="w-full h-32">
+        <path
+          d="M10 50 A40 40 0 0 1 90 50"
+          fill="none"
+          stroke="#1f2937"
+          strokeWidth="6"
+        />
+        <path
+          d="M10 50 A40 40 0 0 1 90 50"
+          fill="none"
+          stroke="#0ea5e9"
+          strokeWidth="6"
+          strokeDasharray="125"
+          strokeDashoffset={125 - (val / max) * 125}
+        />
+        <line
+          x1="50"
+          y1="50"
+          x2="50"
+          y2="15"
+          stroke="#f43f5e"
+          strokeWidth="2"
+          transform={`rotate(${angle} 50 50)`}
+        />
+      </svg>
+      <div className="mt-2 text-center">
+        <p className="text-sm uppercase text-gray-400">{label}</p>
+        <p className="text-xl font-mono text-blue-400">{val}</p>
+      </div>
+    </div>
+  );
+};
+
+export default AnalogGauge;

--- a/frontend/src/components/dashboard/RadarScope.jsx
+++ b/frontend/src/components/dashboard/RadarScope.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+/**
+ * Simple radar scope with sweeping animation using CSS.
+ */
+const RadarScope = () => (
+  <div className="relative bg-gray-800/60 backdrop-blur-lg rounded shadow p-4 h-64 flex items-center justify-center">
+    <div className="radar w-48 h-48 rounded-full border-2 border-green-400 relative overflow-hidden">
+      <div className="radar-sweep absolute inset-0" />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="w-1 h-1 bg-green-400 rounded-full" />
+      </div>
+    </div>
+  </div>
+);
+
+export default RadarScope;

--- a/frontend/src/components/dashboard/ToggleSwitch.jsx
+++ b/frontend/src/components/dashboard/ToggleSwitch.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+/**
+ * Styled toggle switch reminiscent of aircraft cockpit switches.
+ */
+const ToggleSwitch = ({ label, value, onChange }) => (
+  <label className="flex items-center gap-2 cursor-pointer select-none">
+    <span className="text-sm text-gray-300">{label}</span>
+    <input
+      type="checkbox"
+      checked={value}
+      onChange={(e) => onChange(e.target.checked)}
+      className="sr-only"
+    />
+    <span
+      className={`relative inline-block w-12 h-6 rounded-full transition-colors duration-300 ${value ? 'bg-green-500' : 'bg-gray-600'}`}
+    >
+      <span
+        className={`absolute left-0 top-0 w-6 h-6 bg-gray-900 rounded-full transform transition-transform duration-300 ${value ? 'translate-x-6' : ''}`}
+      />
+    </span>
+  </label>
+);
+
+export default ToggleSwitch;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,3 +18,28 @@ body,
 .animate-fade-in {
   animation: fade-in 0.5s ease-in;
 }
+
+/* Cockpit UI custom styles */
+@keyframes radar-sweep {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.radar {
+  background: radial-gradient(circle at center, rgba(16,185,129,0.4) 0%, rgba(0,0,0,0.8) 70%);
+}
+
+.radar-sweep {
+  background: linear-gradient(90deg, rgba(16,185,129,0.4), transparent);
+  animation: radar-sweep 4s linear infinite;
+  transform-origin: 50% 50%;
+}
+
+@keyframes monitor-flicker {
+  0%, 100% { opacity: 0.95; }
+  50% { opacity: 1; }
+}
+
+.flicker {
+  animation: monitor-flicker 0.2s infinite;
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Sidebar from '../components/dashboard/Sidebar';
 import ProfileMenu from '../components/dashboard/ProfileMenu';
 import StatsCard from '../components/dashboard/StatsCard';
@@ -8,6 +8,9 @@ import DataStreamPanel from '../components/dashboard/DataStreamPanel';
 import SocialAccountsPanel from '../components/dashboard/SocialAccountsPanel';
 import ImageGrid from '../components/dashboard/ImageGrid';
 import AlertCenter from '../components/dashboard/AlertCenter';
+import AnalogGauge from '../components/dashboard/AnalogGauge';
+import RadarScope from '../components/dashboard/RadarScope';
+import ToggleSwitch from '../components/dashboard/ToggleSwitch';
 import { motion } from 'framer-motion';
 
 const stats = [
@@ -16,13 +19,27 @@ const stats = [
   { label: 'Active Alerts', value: 9, accent: 'orange' },
 ];
 
-const DashboardPage = () => (
-  <div className="flex h-full bg-gray-900 text-gray-100 font-sans">
-    <Sidebar />
-    <main className="flex-1 overflow-auto p-4 space-y-4">
-      <div className="flex justify-end">
-        <ProfileMenu />
-      </div>
+const DashboardPage = () => {
+  const [systems, setSystems] = useState({ radar: true, gauges: true });
+  return (
+    <div className="flex h-full bg-gray-900 text-gray-100 font-sans flicker">
+      <Sidebar />
+      <main className="flex-1 overflow-auto p-4 space-y-4">
+        <div className="flex justify-between items-center">
+          <ProfileMenu />
+          <div className="flex gap-4">
+            <ToggleSwitch
+              label="Radar"
+              value={systems.radar}
+              onChange={(v) => setSystems((s) => ({ ...s, radar: v }))}
+            />
+            <ToggleSwitch
+              label="Gauges"
+              value={systems.gauges}
+              onChange={(v) => setSystems((s) => ({ ...s, gauges: v }))}
+            />
+          </div>
+        </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {stats.map((s, idx) => (
           <motion.div key={idx} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: idx * 0.1 }}>
@@ -31,6 +48,15 @@ const DashboardPage = () => (
         ))}
       </div>
       <StatsCharts />
+      {systems.gauges && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <AnalogGauge label="Signal" value={80} />
+          <AnalogGauge label="Threat" value={30} />
+          <AnalogGauge label="Load" value={65} />
+          <AnalogGauge label="Integrity" value={95} />
+        </div>
+      )}
+      {systems.radar && <RadarScope />}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <MapWidget />
         <AlertCenter />
@@ -43,5 +69,6 @@ const DashboardPage = () => (
     </main>
   </div>
 );
+};
 
 export default DashboardPage;


### PR DESCRIPTION
## Summary
- introduce cockpit-themed widgets like radar sweep and analog gauges
- add toggle switch control and flicker effects
- integrate new widgets into the dashboard

## Testing
- `npm run build` (fails: `vite: not found`)
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68620b016ccc8330a09be03ddd81140f